### PR TITLE
Time becomes an optional input in the Result Definition

### DIFF
--- a/src/ansys/dpf/composites/composite_model.py
+++ b/src/ansys/dpf/composites/composite_model.py
@@ -243,10 +243,7 @@ class CompositeModel:
             composite_scope = CompositeScope()
         element_scope_in = [] if composite_scope.elements is None else composite_scope.elements
         ply_scope_in = [] if composite_scope.plies is None else composite_scope.plies
-        if composite_scope.time is not None:
-            time_in = composite_scope.time
-        else:
-            time_in = self.get_result_times_or_frequencies()[-1]
+        time_in = composite_scope.time
 
         if composite_scope.plies is None or len(composite_scope.plies):
             # This is a workaround because setting the
@@ -311,10 +308,7 @@ class CompositeModel:
             attribute. This parameter is only required for assemblies.
             See the note about assemblies in the description for the :class:`CompositeModel` class.
         """
-        if time is None:
-            time_in = self.get_result_times_or_frequencies()[-1]
-        else:
-            time_in = time
+        time_in = time
 
         if composite_definition_label is None:
             # jvonrick: Jan 2023: We could also try to determine composite_definition_label

--- a/src/ansys/dpf/composites/result_definition.py
+++ b/src/ansys/dpf/composites/result_definition.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from enum import Enum
 import json
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Union
 
 from ._typing_helper import PATH as _PATH
 from .failure_criteria import CombinedFailureCriterion
@@ -69,7 +69,7 @@ class ResultDefinition:
         material_file: _PATH,
         measure: str = "inverse_reserve_factor",
         stress_strain_eval_mode: str = "rst_file",
-        time: float = 1.0,
+        time: Union[float, None] = None,
         expression: str = "composite_failure",
         max_chunk_size: int = 50000,
     ):
@@ -187,8 +187,10 @@ class ResultDefinition:
             )
 
     @property
-    def time(self) -> float:
+    def time(self) -> Union[float, None]:
         """Time or solution step.
+
+        DPF Composites automatically selects the last time step if time is not set.
 
         You can use the :meth:`.CompositeModel.get_result_times_or_frequencies` method
         to list the available times or frequencies in the result file.
@@ -196,7 +198,7 @@ class ResultDefinition:
         return self._time
 
     @time.setter
-    def time(self, value: float) -> None:
+    def time(self, value: Union[float, None]) -> None:
         self._time = value
 
     @property
@@ -231,9 +233,11 @@ class ResultDefinition:
             "failure_criteria_definition": {cfc.JSON_DICT_KEY: cfc.to_dict()},
             "measures": [self.measure],
             "stress_strain_eval_mode": f"{self.stress_strain_eval_mode}",
-            "time": self.time,
             "max_chunk_size": self.max_chunk_size,
         }
+
+        if self.time:
+            result_definition["time"] = self.time
 
         def get_scope(
             result_definition_scope: ResultDefinitionScope, rst_file: _PATH, material_file: _PATH

--- a/tests/result_definition_test.py
+++ b/tests/result_definition_test.py
@@ -16,7 +16,7 @@ defaults: Dict[str, Any] = {
     "expression": "composite_failure",
     "measure": "inverse_reserve_factor",
     "stress_strain_eval_mode": "rst_file",
-    "time": 1.0,
+    "time": None,
     "max_chunk_size": 50000,
 }
 
@@ -143,6 +143,11 @@ def test_result_definition():
         ],
     }
 
+    assert rd.to_dict() == ref_dict
+
+    # check result definition is time is not set (None)
+    rd.time = None
+    ref_dict.pop("time")
     assert rd.to_dict() == ref_dict
 
     # test reprs


### PR DESCRIPTION
closes #130 

Time becomes an optional input in the Result Definition since the backend now automatically selects the last time / frequency.