### PR TITLE
Disable the 'force-orphan' option in the doc deployment

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -155,9 +155,13 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: "Install Python dependencies"
+      # TODO: remove 'poetry config installer.modern-installation false' once we use a pydata-sphinx-theme
+      # version where https://github.com/pydata/pydata-sphinx-theme/issues/1253 is resolved.
+      # The same needs to be removed in the README.
         run: |
           python -m pip install --upgrade pip tox
           python -m pip install --upgrade poetry
+          poetry config installer.modern-installation false
 
       - name: "Generate the documentation with tox"
         run: |

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -205,6 +205,7 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          force-orphan: false
 
   release:
     name: "Release project"
@@ -235,3 +236,4 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          force-orphan: false

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,12 @@ familiar with the `PyAnsys Developer's Guide`_.
 
     .. code:: bash
 
+        poetry config installer.modern-installation false
         poetry install --all-extras
+
+    Setting ``installer.modern-installation`` to ``false`` is a temporary workaround.
+    See `this pydata-sphinx-theme issue <https://github.com/pydata/pydata-sphinx-theme/issues/1253>`_
+    for more information.
 
 
 #.  Activate the virtual environment:


### PR DESCRIPTION
Disable the `force-orphan` option when deploying the documentation,
 which causes the `gh-pages` branch to be truncated, only retaining
the last commit.
This is incompatible with the linear history requirement in our branch 
protection rules.

Add a temporary workaround for https://github.com/pydata/pydata-sphinx-theme/issues/1253,
by setting the `installer.modern-installation` poetry setting to `false`.