### PR TITLE
Aligning to v4 PyAnsys actions multi-version docs (release/0.1)

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -231,7 +231,7 @@ jobs:
     needs: [release]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
     steps:
-      - uses: pyansys/actions/doc-deploy-stable@v3
+      - uses: pyansys/actions/doc-deploy-stable@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,7 +44,7 @@ html_theme_options = {
         ("PyAnsys", "https://docs.pyansys.com/"),
     ],
     "switcher": {
-        "json_url": f"https://{cname}/release/versions.json",
+        "json_url": f"https://{cname}/versions.json",
         "version_match": get_version_match(__version__),
     },
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,23 +80,23 @@ grpcio = "*"
 
 [[package]]
 name = "ansys-sphinx-theme"
-version = "0.9.5"
+version = "0.8.1"
 description = "A theme devised by ANSYS, Inc. for Sphinx documentation."
 category = "main"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.5"
 files = [
-    {file = "ansys-sphinx-theme-0.9.5.tar.gz", hash = "sha256:acdbc0f1b67951f43848e2cc9d02725c85bd85ed6ded307163f33813c8454559"},
-    {file = "ansys_sphinx_theme-0.9.5-py3-none-any.whl", hash = "sha256:2871e834d139565f140805fb42f4f2b3b9faad37ff28df20bb94801afeba5e18"},
+    {file = "ansys-sphinx-theme-0.8.1.tar.gz", hash = "sha256:2a74f74d0f818ad4c1bf6a52e7e38b75df29c866f7ef1023605891308b197890"},
+    {file = "ansys_sphinx_theme-0.8.1-py3-none-any.whl", hash = "sha256:8cc4d2c15e73b26dea0a4fc1fc59f6202d261100314d5443ce904c131306653c"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1.2"
-pydata-sphinx-theme = "0.12.0"
-Sphinx = ">=4.2.0,<6"
+pydata-sphinx-theme = "0.9.0"
+Sphinx = ">=4.0.0"
 
 [package.extras]
-doc = ["Sphinx (==5.3.0)", "bs4 (==0.0.1)", "html5lib (==1.1)", "numpydoc (==1.5.0)", "requests (==2.28.2)", "sphinx-copybutton (==0.5.1)", "sphinx-design (==0.3.0)", "sphinx-jinja (==2.0.2)", "sphinx-notfound-page (==0.8.3)"]
+doc = ["Sphinx (==5.3.0)", "numpydoc (==1.5.0)", "sphinx-copybutton (==0.5.1)", "sphinx-notfound-page (==0.8.3)"]
 
 [[package]]
 name = "appdirs"

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,23 +80,23 @@ grpcio = "*"
 
 [[package]]
 name = "ansys-sphinx-theme"
-version = "0.8.1"
+version = "0.9.5"
 description = "A theme devised by ANSYS, Inc. for Sphinx documentation."
 category = "main"
 optional = true
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 files = [
-    {file = "ansys-sphinx-theme-0.8.1.tar.gz", hash = "sha256:2a74f74d0f818ad4c1bf6a52e7e38b75df29c866f7ef1023605891308b197890"},
-    {file = "ansys_sphinx_theme-0.8.1-py3-none-any.whl", hash = "sha256:8cc4d2c15e73b26dea0a4fc1fc59f6202d261100314d5443ce904c131306653c"},
+    {file = "ansys-sphinx-theme-0.9.5.tar.gz", hash = "sha256:acdbc0f1b67951f43848e2cc9d02725c85bd85ed6ded307163f33813c8454559"},
+    {file = "ansys_sphinx_theme-0.9.5-py3-none-any.whl", hash = "sha256:2871e834d139565f140805fb42f4f2b3b9faad37ff28df20bb94801afeba5e18"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1.2"
-pydata-sphinx-theme = "0.9.0"
-Sphinx = ">=4.0.0"
+pydata-sphinx-theme = "0.12.0"
+Sphinx = ">=4.2.0,<6"
 
 [package.extras]
-doc = ["Sphinx (==5.3.0)", "numpydoc (==1.5.0)", "sphinx-copybutton (==0.5.1)", "sphinx-notfound-page (==0.8.3)"]
+doc = ["Sphinx (==5.3.0)", "bs4 (==0.0.1)", "html5lib (==1.1)", "numpydoc (==1.5.0)", "requests (==2.28.2)", "sphinx-copybutton (==0.5.1)", "sphinx-design (==0.3.0)", "sphinx-jinja (==2.0.2)", "sphinx-notfound-page (==0.8.3)"]
 
 [[package]]
 name = "appdirs"


### PR DESCRIPTION
See https://dev.docs.pyansys.com/how-to/documenting.html#multi-version-migration-from-pyansys-actions-v3-to-pyansys-actions-v4

Doing it as a patch-fix. We can keep this ansys-sphinx-theme version still (0.8.1). No need to release. It's only in case you need to do a patch release at some point on ``release/0.1``