### PR TITLE
Remove the poetry workaround for sphinx theme installation

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -162,13 +162,9 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: "Install Python dependencies"
-      # TODO: remove 'poetry config installer.modern-installation false' once we use a pydata-sphinx-theme
-      # version where https://github.com/pydata/pydata-sphinx-theme/issues/1253 is resolved.
-      # The same needs to be removed in the README.
         run: |
           python -m pip install --upgrade pip tox
           python -m pip install --upgrade poetry
-          poetry config installer.modern-installation false
 
       - name: "Generate the documentation with tox"
         run: |

--- a/README.rst
+++ b/README.rst
@@ -81,12 +81,7 @@ familiar with the `PyAnsys Developer's Guide`_.
 
     .. code:: bash
 
-        poetry config installer.modern-installation false
         poetry install --all-extras
-
-    Setting ``installer.modern-installation`` to ``false`` is a temporary workaround.
-    See `this pydata-sphinx-theme issue <https://github.com/pydata/pydata-sphinx-theme/issues/1253>`_
-    for more information.
 
 
 #.  Activate the virtual environment:


### PR DESCRIPTION
After the upgrade to `ansys-sphinx-theme==0.9.6`, we no longer
need to set `poetry config installer.modern-installation false`.

See https://github.com/pydata/pydata-sphinx-theme/issues/1253
for context.