### PR TITLE
Update pre-commit dependencies, remove code obsolete with Python 3.7 drop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,12 @@ repos:
   hooks:
   - id: isort
 
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.3.1
+  hooks:
+  - id: pyupgrade
+    args: [--py38-plus]
+
 - repo: https://github.com/PyCQA/flake8
   rev: 6.0.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/psf/black
-  rev: 22.12.0  # IF VERSION CHANGES --> MODIFY "blacken-docs" MANUALLY AS WELL!!
+  rev: 23.3.0  # IF VERSION CHANGES --> MODIFY "blacken-docs" MANUALLY AS WELL!!
   hooks:
   - id: black
 
@@ -9,7 +9,7 @@ repos:
   rev: 1.13.0
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==22.12.0]
+    additional_dependencies: [black==23.3.0]
     exclude: "^tests/"
 
 - repo: https://github.com/pycqa/isort
@@ -30,10 +30,11 @@ repos:
     exclude: "^(tests/|examples/)"
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.2
+  rev: v2.2.4
   hooks:
   - id: codespell
     additional_dependencies: ['tomli'] # needed to parse pyproject.toml
+    exclude: '^poetry\.lock$'
 
 - repo: local
   hooks:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -80,7 +80,7 @@ nitpick_ignore = [
     ("py:class", "int64"),
 ]
 nitpick_ignore_regex = [
-    ("py:class", "numpy\..*"),
+    ("py:class", r"numpy\..*"),
     ("py:class", ".*FailureCriterionBase"),  # implementation detail, not documented
 ]
 

--- a/examples/4_get_material_properties_example.py
+++ b/examples/4_get_material_properties_example.py
@@ -11,7 +11,7 @@ all layers and integration points. Finally, the elemental maximum is computed an
 Note: Only constant material properties are currently supported.
 """
 
-#%%
+# %%
 # Script
 # ~~~~~~
 #
@@ -32,11 +32,11 @@ from ansys.dpf.composites.server_helpers import connect_to_or_start_server
 server = connect_to_or_start_server()
 composite_files_on_server = get_continuous_fiber_example_files(server, "shell")
 
-#%%
+# %%
 # Set up the composite model
 composite_model = CompositeModel(composite_files_on_server, server)
 
-#%%
+# %%
 # Get dictionary that maps dpf_material_id to properties
 # The creation of the dictionary is currently quite slow and
 # should be done before using the properties in a loop.
@@ -47,14 +47,14 @@ material_property = MaterialProperty.Strain_Limits_eXt
 property_dict = composite_model.get_constant_property_dict([material_property])
 
 
-#%%
+# %%
 # Get strain field
 strain_operator = composite_model.core_model.results.elastic_strain()
 strain_operator.inputs.bool_rotate_to_global(False)
 strain_field = strain_operator.get_output(pin=0, output_type=dpf.types.fields_container)[0]
 
 
-#%%
+# %%
 # Implement a custom failure criterion: basic max strain
 result_field = dpf.field.Field(location=dpf.locations.elemental, nature=dpf.natures.scalar)
 

--- a/examples/5_get_layup_properties_example.py
+++ b/examples/5_get_layup_properties_example.py
@@ -11,7 +11,7 @@ postprocessing and data filtering.
 To get the full layer information of an element, including results,
 consider using the :class:`SamplingPoint <.SamplingPoint>` class.
 """
-#%%
+# %%
 # Set up analysis
 # ~~~~~~~~~~~~~~~
 # Setting up the analysis consists of importing dependencies, connecting to the
@@ -30,13 +30,13 @@ from ansys.dpf.composites.server_helpers import connect_to_or_start_server
 server = connect_to_or_start_server()
 composite_files_on_server = get_continuous_fiber_example_files(server, "shell")
 
-#%%
+# %%
 # Set up model
 # ~~~~~~~~~~~~
 # Set up the composite model.
 composite_model = CompositeModel(composite_files_on_server, server)
 
-#%%
+# %%
 # Get lay-up properties
 # ~~~~~~~~~~~~~~~~~~~~~
 # Get lay-up properties for all elements and show the first one as an example.
@@ -48,7 +48,7 @@ offset = composite_model.get_element_laminate_offset(element_id)
 analysis_plies = composite_model.get_analysis_plies(element_id)
 
 
-#%%
+# %%
 # Plot lay-up properties
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Plot basic layer properties (layer thicknesses, angles, and analysis ply names).

--- a/examples/dpf_composite_failure_workflow.py
+++ b/examples/dpf_composite_failure_workflow.py
@@ -19,7 +19,7 @@ operators that are needed to evaluate composite failure criteria.
 
 """
 
-#%%
+# %%
 # Set up analysis
 # ~~~~~~~~~~~~~~~
 # Setting up the analysis consists of loading Ansys libraries, configuring
@@ -44,7 +44,7 @@ from ansys.dpf.composites.failure_criteria import (
 )
 from ansys.dpf.composites.server_helpers import connect_to_or_start_server
 
-#%%
+# %%
 # Configure the combined failure criterion.
 combined_fc = CombinedFailureCriterion(
     name="My Failure Criteria",

--- a/minimum_requirements.txt
+++ b/minimum_requirements.txt
@@ -1,4 +1,4 @@
 # Contains minimum requirements that we support
-numpy == 1.19.0
+numpy == 1.22.0
 matplotlib == 3.5.0
 ansys-dpf-core == 0.7.3

--- a/src/ansys/dpf/composites/_indexer.py
+++ b/src/ansys/dpf/composites/_indexer.py
@@ -1,25 +1,17 @@
 """Indexer helper classes."""
 from dataclasses import dataclass
-import sys
-from typing import TYPE_CHECKING, Optional, cast
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
+from typing import Optional, Protocol, cast
 
 from ansys.dpf.core import Field, PropertyField, Scoping
 import numpy as np
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
+from numpy.typing import NDArray
 
 
 @dataclass(frozen=True)
 class IndexToId:
     """Mapping maps id to index."""
 
-    mapping: "NDArray[np.int64]"
+    mapping: NDArray[np.int64]
     max_id: int
 
 
@@ -33,7 +25,7 @@ def setup_index_by_id(scoping: Scoping) -> IndexToId:
     scoping:
         DPF scoping
     """
-    indices: "NDArray[np.int64]" = np.full(max(scoping.ids) + 1, -1, dtype=np.int64)
+    indices: NDArray[np.int64] = np.full(max(scoping.ids) + 1, -1, dtype=np.int64)
     indices[scoping.ids] = np.arange(len(scoping.ids))
     return IndexToId(mapping=indices, max_id=len(indices) - 1)
 
@@ -48,7 +40,7 @@ class PropertyFieldIndexerSingleValue(Protocol):
 class PropertyFieldIndexerArrayValue(Protocol):
     """Protocol for array valued property field indexer."""
 
-    def by_id(self, entity_id: int) -> Optional["NDArray[np.int64]"]:
+    def by_id(self, entity_id: int) -> Optional[NDArray[np.int64]]:
         """Get index by id."""
 
 
@@ -70,7 +62,7 @@ class PropertyFieldIndexerNoDataPointer:
         index_by_id = setup_index_by_id(field.scoping)
         self._indices = index_by_id.mapping
         self._max_id = index_by_id.max_id
-        self._data: "NDArray[np.int64]" = np.array(field.data, dtype=np.int64)
+        self._data: NDArray[np.int64] = np.array(field.data, dtype=np.int64)
 
     def by_id(self, entity_id: int) -> Optional[np.int64]:
         """Get index by id.
@@ -96,7 +88,7 @@ class FieldIndexerNoDataPointer:
         index_by_id = setup_index_by_id(field.scoping)
         self._indices = index_by_id.mapping
         self._max_id = index_by_id.max_id
-        self._data: "NDArray[np.double]" = np.array(field.data, dtype=np.double)
+        self._data: NDArray[np.double] = np.array(field.data, dtype=np.double)
 
     def by_id(self, entity_id: int) -> Optional[np.double]:
         """Get index by id.
@@ -120,7 +112,7 @@ class PropertyFieldIndexerNoDataPointerNoBoundsCheck:
         """Create indexer and get data."""
         index_by_id = setup_index_by_id(field.scoping)
         self._indices = index_by_id.mapping
-        self._data: "NDArray[np.int64]" = np.array(field.data, dtype=np.int64)
+        self._data: NDArray[np.int64] = np.array(field.data, dtype=np.int64)
 
     def by_id(self, entity_id: int) -> Optional[np.int64]:
         """Get index by id.
@@ -141,14 +133,14 @@ class PropertyFieldIndexerWithDataPointer:
         self._indices = index_by_id.mapping
         self._max_id = index_by_id.max_id
 
-        self._data: "NDArray[np.int64]" = np.array(field.data, dtype=np.int64)
+        self._data: NDArray[np.int64] = np.array(field.data, dtype=np.int64)
         self._n_components = field.component_count
 
-        self._data_pointer: "NDArray[np.int64]" = np.append(
+        self._data_pointer: NDArray[np.int64] = np.append(
             field._data_pointer, len(self._data) * self._n_components
         )
 
-    def by_id(self, entity_id: int) -> Optional["NDArray[np.int64]"]:
+    def by_id(self, entity_id: int) -> Optional[NDArray[np.int64]]:
         """Get index by id.
 
         Parameters
@@ -162,7 +154,7 @@ class PropertyFieldIndexerWithDataPointer:
         if idx < 0:
             return None
         return cast(
-            "NDArray[np.int64]",
+            NDArray[np.int64],
             self._data[
                 self._data_pointer[idx]
                 // self._n_components : self._data_pointer[idx + 1]
@@ -180,14 +172,14 @@ class FieldIndexerWithDataPointer:
         self._indices = index_by_id.mapping
         self._max_id = index_by_id.max_id
 
-        self._data: "NDArray[np.double]" = np.array(field.data, dtype=np.double)
+        self._data: NDArray[np.double] = np.array(field.data, dtype=np.double)
         self._n_components = field.component_count
 
-        self._data_pointer: "NDArray[np.int64]" = np.append(
+        self._data_pointer: NDArray[np.int64] = np.append(
             field._data_pointer, len(self._data) * self._n_components
         )
 
-    def by_id(self, entity_id: int) -> Optional["NDArray[np.double]"]:
+    def by_id(self, entity_id: int) -> Optional[NDArray[np.double]]:
         """Get index by id.
 
         Parameters
@@ -201,7 +193,7 @@ class FieldIndexerWithDataPointer:
         if idx < 0:
             return None
         return cast(
-            "NDArray[np.double]",
+            NDArray[np.double],
             self._data[
                 self._data_pointer[idx]
                 // self._n_components : self._data_pointer[idx + 1]
@@ -218,15 +210,15 @@ class PropertyFieldIndexerWithDataPointerNoBoundsCheck:
         index_by_id = setup_index_by_id(field.scoping)
         self._indices = index_by_id.mapping
 
-        self._data: "NDArray[np.int64]" = np.array(field.data, dtype=np.int64)
+        self._data: NDArray[np.int64] = np.array(field.data, dtype=np.int64)
 
         self._n_components = field.component_count
 
-        self._data_pointer: "NDArray[np.int64]" = np.append(
+        self._data_pointer: NDArray[np.int64] = np.append(
             field._data_pointer, len(self._data) * self._n_components
         )
 
-    def by_id(self, entity_id: int) -> Optional["NDArray[np.int64]"]:
+    def by_id(self, entity_id: int) -> Optional[NDArray[np.int64]]:
         """Get index by id.
 
         Parameters
@@ -237,7 +229,7 @@ class PropertyFieldIndexerWithDataPointerNoBoundsCheck:
         if idx < 0:
             return None
         return cast(
-            "NDArray[np.int64]",
+            NDArray[np.int64],
             self._data[
                 self._data_pointer[idx]
                 // self._n_components : self._data_pointer[idx + 1]

--- a/src/ansys/dpf/composites/composite_model.py
+++ b/src/ansys/dpf/composites/composite_model.py
@@ -1,16 +1,12 @@
 """Composite Model."""
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Collection, Dict, List, Optional, Sequence, cast
+from typing import Collection, Dict, List, Optional, Sequence, cast
 
 import ansys.dpf.core as dpf
 from ansys.dpf.core import FieldsContainer, MeshedRegion, Operator, UnitSystem
 from ansys.dpf.core.server_types import BaseServer
 import numpy as np
-
-from .unit_system import UnitSystemProvider, get_unit_system
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
+from numpy.typing import NDArray
 
 from .data_sources import (
     CompositeDataSources,
@@ -29,6 +25,7 @@ from .layup_info.material_operators import MaterialOperators, get_material_opera
 from .layup_info.material_properties import MaterialProperty, get_constant_property_dict
 from .result_definition import FailureMeasure, ResultDefinition, ResultDefinitionScope
 from .sampling_point import SamplingPoint
+from .unit_system import UnitSystemProvider, get_unit_system
 
 __all__ = ("CompositeScope", "CompositeInfo", "CompositeModel")
 
@@ -397,7 +394,7 @@ class CompositeModel:
         layup_property: LayerProperty,
         element_id: int,
         composite_definition_label: Optional[str] = None,
-    ) -> Optional["NDArray[np.double]"]:
+    ) -> Optional[NDArray[np.double]]:
         """Get a layer property for an element ID.
 
         Returns a numpy array with the values of the property for all the layers.
@@ -516,10 +513,10 @@ class CompositeModel:
             mesh=self.get_mesh(composite_definition_label),
         )
 
-    def get_result_times_or_frequencies(self) -> "NDArray[np.double]":
+    def get_result_times_or_frequencies(self) -> NDArray[np.double]:
         """Get the times or frequencies in the result file."""
         return cast(
-            "NDArray[np.double]", self._core_model.metadata.time_freq_support.time_frequencies.data
+            NDArray[np.double], self._core_model.metadata.time_freq_support.time_frequencies.data
         )
 
     def add_interlaminar_normal_stresses(

--- a/src/ansys/dpf/composites/layup_info/_layup_info.py
+++ b/src/ansys/dpf/composites/layup_info/_layup_info.py
@@ -112,7 +112,6 @@ def _is_shell(apdl_element_type: np.int64) -> bool:
 
 
 def _get_n_spots(apdl_element_type: np.int64, keyopt_8: np.int64, keyopt_3: np.int64) -> int:
-
     if keyopt_3 == 0:
         if apdl_element_type == 185 or apdl_element_type == 186:
             return 0
@@ -244,7 +243,6 @@ def get_analysis_ply_index_to_name_map(
     """
     analysis_ply_name_to_index_map = {}
     with mesh.property_field("layer_to_analysis_ply").as_local_field() as local_field:
-
         for analysis_ply_name in get_all_analysis_ply_names(mesh):
             analysis_ply_property_field = _get_analysis_ply(
                 mesh, analysis_ply_name, skip_check=True

--- a/src/ansys/dpf/composites/layup_info/_layup_info.py
+++ b/src/ansys/dpf/composites/layup_info/_layup_info.py
@@ -1,14 +1,12 @@
 """Lay-up information provider."""
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Collection, Dict, List, Optional, Sequence, Union, cast
+from typing import Any, Collection, Dict, List, Optional, Sequence, Union, cast
 
 import ansys.dpf.core as dpf
 from ansys.dpf.core import DataSources, MeshedRegion, Operator, PropertyField
 import numpy as np
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
+from numpy.typing import NDArray
 
 from .._indexer import (
     FieldIndexerNoDataPointer,
@@ -84,7 +82,7 @@ class ElementInfo:
     n_spots: int
     is_layered: bool
     element_type: int
-    dpf_material_ids: "NDArray[np.int64]"
+    dpf_material_ids: NDArray[np.int64]
     is_shell: bool
     number_of_nodes_per_spot_plane: int
 
@@ -126,12 +124,12 @@ def _get_n_spots(apdl_element_type: np.int64, keyopt_8: np.int64, keyopt_3: np.i
         ) from exc
 
 
-def _get_corner_nodes_by_element_type_array() -> "NDArray[np.int64]":
+def _get_corner_nodes_by_element_type_array() -> NDArray[np.int64]:
     # Precompute n_corner_nodes for all element types
     # corner_nodes_by_element_type by can be indexed by element type to get the number of
     # corner nodes. If negative value is returned number of corner nodes is not available.
     all_element_types = [int(e.value) for e in dpf.element_types if e.value >= 0]
-    corner_nodes_by_element_type: "NDArray[np.int64]" = np.full(
+    corner_nodes_by_element_type: NDArray[np.int64] = np.full(
         np.amax(all_element_types) + 1, -1, dtype=np.int64
     )
 
@@ -489,7 +487,7 @@ class LayupPropertiesProvider:
             mesh.property_field("layer_to_analysis_ply")
         )
 
-    def get_layer_angles(self, element_id: int) -> Optional["NDArray[np.double]"]:
+    def get_layer_angles(self, element_id: int) -> Optional[NDArray[np.double]]:
         """Get angles for all layers. Returns None if element is not layered.
 
         Parameters
@@ -499,7 +497,7 @@ class LayupPropertiesProvider:
         """
         return self._angle_indexer.by_id(element_id)
 
-    def get_layer_thicknesses(self, element_id: int) -> Optional["NDArray[np.double]"]:
+    def get_layer_thicknesses(self, element_id: int) -> Optional[NDArray[np.double]]:
         """Get thicknesses for all layers. Returns None if element is not layered.
 
         Parameters
@@ -510,7 +508,7 @@ class LayupPropertiesProvider:
         """
         return self._thickness_indexer.by_id(element_id)
 
-    def get_layer_shear_angles(self, element_id: int) -> Optional["NDArray[np.double]"]:
+    def get_layer_shear_angles(self, element_id: int) -> Optional[NDArray[np.double]]:
         """Get shear angle for all layers. Returns None if element is not layered.
 
         Parameters

--- a/src/ansys/dpf/composites/sampling_point.py
+++ b/src/ansys/dpf/composites/sampling_point.py
@@ -2,7 +2,7 @@
 import dataclasses
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, Collection, Dict, List, Sequence, Union, cast
+from typing import Any, Collection, Dict, List, Sequence, Union, cast
 
 import ansys.dpf.core as dpf
 from ansys.dpf.core.server import get_or_create_server
@@ -11,9 +11,7 @@ from matplotlib.axes import SubplotBase
 from matplotlib.patches import Rectangle
 import matplotlib.pyplot as plt
 import numpy as np
-
-if TYPE_CHECKING:
-    import numpy.typing as npt
+import numpy.typing as npt
 
 from .constants import Spot
 from .result_definition import FailureMeasure, ResultDefinition
@@ -212,85 +210,85 @@ class SamplingPoint:
         return plies
 
     @property
-    def s1(self) -> "npt.NDArray[np.float64]":
+    def s1(self) -> npt.NDArray[np.float64]:
         """Stresses in the material 1 direction of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["stresses"]["s1"])
 
     @property
-    def s2(self) -> "npt.NDArray[np.float64]":
+    def s2(self) -> npt.NDArray[np.float64]:
         """Stresses in the material 2 direction of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["stresses"]["s2"])
 
     @property
-    def s3(self) -> "npt.NDArray[np.float64]":
+    def s3(self) -> npt.NDArray[np.float64]:
         """Stresses in the material 3 direction of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["stresses"]["s3"])
 
     @property
-    def s12(self) -> "npt.NDArray[np.float64]":
+    def s12(self) -> npt.NDArray[np.float64]:
         """In-plane shear stresses s12 of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["stresses"]["s12"])
 
     @property
-    def s13(self) -> "npt.NDArray[np.float64]":
+    def s13(self) -> npt.NDArray[np.float64]:
         """Out-of-plane shear stresses s13 of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["stresses"]["s13"])
 
     @property
-    def s23(self) -> "npt.NDArray[np.float64]":
+    def s23(self) -> npt.NDArray[np.float64]:
         """Out-of-plane shear stresses s23 of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["stresses"]["s23"])
 
     @property
-    def e1(self) -> "npt.NDArray[np.float64]":
+    def e1(self) -> npt.NDArray[np.float64]:
         """Strains in the material 1 direction of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["strains"]["e1"])
 
     @property
-    def e2(self) -> "npt.NDArray[np.float64]":
+    def e2(self) -> npt.NDArray[np.float64]:
         """Strains in the material 2 direction of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["strains"]["e2"])
 
     @property
-    def e3(self) -> "npt.NDArray[np.float64]":
+    def e3(self) -> npt.NDArray[np.float64]:
         """Strains in the material 3 direction of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["strains"]["e3"])
 
     @property
-    def e12(self) -> "npt.NDArray[np.float64]":
+    def e12(self) -> npt.NDArray[np.float64]:
         """In-plane shear strains e12 of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["strains"]["e12"])
 
     @property
-    def e13(self) -> "npt.NDArray[np.float64]":
+    def e13(self) -> npt.NDArray[np.float64]:
         """Out-of-plane shear strains e13 of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["strains"]["e13"])
 
     @property
-    def e23(self) -> "npt.NDArray[np.float64]":
+    def e23(self) -> npt.NDArray[np.float64]:
         """Out-of-plane shear strains e23 of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["strains"]["e13"])
 
     @property
-    def inverse_reserve_factor(self) -> "npt.NDArray[np.float64]":
+    def inverse_reserve_factor(self) -> npt.NDArray[np.float64]:
         """Critical inverse reserve factor of each ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["failures"]["inverse_reserve_factor"])
 
     @property
-    def reserve_factor(self) -> "npt.NDArray[np.float64]":
+    def reserve_factor(self) -> npt.NDArray[np.float64]:
         """Lowest reserve factor of each ply.
 
         This attribute is equivalent to the safety factor.
@@ -299,7 +297,7 @@ class SamplingPoint:
         return np.array(self._results[0]["results"]["failures"]["reserve_factor"])
 
     @property
-    def margin_of_safety(self) -> "npt.NDArray[np.float64]":
+    def margin_of_safety(self) -> npt.NDArray[np.float64]:
         """Lowest margin of safety of each ply.
 
         This attribute is equivalent to the safety margin.
@@ -314,19 +312,19 @@ class SamplingPoint:
         return cast(Sequence[str], self._results[0]["results"]["failures"]["failure_modes"])
 
     @property
-    def offsets(self) -> "npt.NDArray[np.float64]":
+    def offsets(self) -> npt.NDArray[np.float64]:
         """Z coordinates for each interface and ply."""
         self._update_and_check_results()
         return np.array(self._results[0]["results"]["offsets"])
 
     @property
-    def polar_properties_E1(self) -> "npt.NDArray[np.float64]":
+    def polar_properties_E1(self) -> npt.NDArray[np.float64]:
         """Polar property E1 of the laminate."""
         self._update_and_check_results()
         return np.array(self._results[0]["layup"]["polar_properties"]["E1"])
 
     @property
-    def polar_properties_E2(self) -> "npt.NDArray[np.float64]":
+    def polar_properties_E2(self) -> npt.NDArray[np.float64]:
         """Polar property E2 of the laminate."""
         if not self._isuptodate or not self._results:
             self.run()
@@ -337,7 +335,7 @@ class SamplingPoint:
         return np.array(self._results[0]["layup"]["polar_properties"]["E2"])
 
     @property
-    def polar_properties_G12(self) -> "npt.NDArray[np.float64]":
+    def polar_properties_G12(self) -> npt.NDArray[np.float64]:
         """Polar property G12 of the laminate."""
         if not self._isuptodate or not self._results:
             self.run()
@@ -434,7 +432,7 @@ class SamplingPoint:
         self,
         spots: Collection[Spot] = (Spot.BOTTOM, Spot.MIDDLE, Spot.TOP),
         core_scale_factor: float = 1.0,
-    ) -> "npt.NDArray[np.float64]":
+    ) -> npt.NDArray[np.float64]:
         """Access the y coordinates of the selected spots (interfaces) for each ply.
 
         Parameters
@@ -449,7 +447,7 @@ class SamplingPoint:
         indices = self.get_indices(spots)
 
         if core_scale_factor == 1.0:
-            return cast("npt.NDArray[np.float64]", offsets[indices])
+            return cast(npt.NDArray[np.float64], offsets[indices])
 
         thicknesses = []
         if not self.analysis_plies:
@@ -476,7 +474,7 @@ class SamplingPoint:
             for i in range(0, self._spots_per_ply):
                 offsets[index * self._spots_per_ply + i] = top_of_previous_ply + step * i
 
-        return cast("npt.NDArray[np.float64]", offsets[indices])
+        return cast(npt.NDArray[np.float64], offsets[indices])
 
     def get_ply_wise_critical_failures(self) -> List[FailureResult]:
         """Get the critical failure value and modes per ply."""

--- a/src/ansys/dpf/composites/sampling_point.py
+++ b/src/ansys/dpf/composites/sampling_point.py
@@ -423,7 +423,6 @@ class SamplingPoint:
         ply_wise_indices.sort()
         indices = []
         if self.analysis_plies:
-
             for ply_index in range(0, self.number_of_plies):
                 indices.extend(
                     [ply_index * self._spots_per_ply + index for index in ply_wise_indices]
@@ -753,7 +752,6 @@ class SamplingPoint:
                 )
 
                 if show_failure_modes:
-
                     middle_offsets = self.get_offsets_by_spots(
                         spots=[Spot.MIDDLE], core_scale_factor=core_scale_factor
                     )

--- a/src/ansys/dpf/composites/select_indices.py
+++ b/src/ansys/dpf/composites/select_indices.py
@@ -1,10 +1,8 @@
 """Functions to get elementary indices based on filter input."""
-from typing import TYPE_CHECKING, Collection, Optional
+from typing import Collection, Optional
 
 import numpy as np
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
+from numpy.typing import NDArray
 
 from .constants import Spot
 from .layup_info import AnalysisPlyInfoProvider, ElementInfo
@@ -30,7 +28,7 @@ def get_selected_indices(
     nodes: Optional[Collection[int]] = None,
     spots: Optional[Collection[Spot]] = None,
     disable_checks: bool = False,
-) -> "NDArray[np.int64]":
+) -> NDArray[np.int64]:
     """Get elementary indices based on element information, layers, nodes, and spots.
 
     Parameters
@@ -127,7 +125,7 @@ def get_selected_indices(
 
 def get_selected_indices_by_dpf_material_ids(
     element_info: ElementInfo, dpf_material_ids: Collection[np.int64]
-) -> "NDArray[np.int64]":
+) -> NDArray[np.int64]:
     """Get selected indices by DPF material IDs.
 
     This method selects all indices that are in a layer with one of the selected materials.
@@ -155,7 +153,7 @@ def get_selected_indices_by_dpf_material_ids(
 
 def get_selected_indices_by_analysis_ply(
     analysis_ply_info_provider: AnalysisPlyInfoProvider, element_info: ElementInfo
-) -> "NDArray[np.int64]":
+) -> NDArray[np.int64]:
     """Get selected indices by analysis ply.
 
     Selects all indices that are in a layer with the given analysis ply

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,7 +272,6 @@ def _find_free_port() -> int:
 
 @pytest.fixture(scope="session")
 def dpf_server(request: pytest.FixtureRequest):
-
     # Use a unique session id so logs don't get overwritten
     # by tests that run in different sessions
     import uuid
@@ -317,7 +316,6 @@ def dpf_server(request: pytest.FixtureRequest):
         if installer_path:
             return InstalledServer(installer_path)
         else:
-
             process_log_stdout = TEST_ROOT_DIR / "logs" / f"process_log_out-{uid}.txt"
             process_log_stderr = TEST_ROOT_DIR / "logs" / f"process_log_err-{uid}.txt"
 

--- a/tests/failure_criteria/combined_failure_criterion_test.py
+++ b/tests/failure_criteria/combined_failure_criterion_test.py
@@ -6,7 +6,6 @@ from ansys.dpf.composites.failure_criteria._max_stress import MaxStressCriterion
 
 
 def test_combined_failure_criterion():
-
     cfc = CombinedFailureCriterion("my name")
     assert cfc.name == "my name"
 

--- a/tests/failure_criteria/core_failure_test.py
+++ b/tests/failure_criteria/core_failure_test.py
@@ -7,7 +7,6 @@ defaults = dict(zip(ATTRS_CORE_FAILURE, [False, 1.0]))
 
 
 def test_core_failure_criterion():
-
     cf_default = CoreFailureCriterion()
     assert cf_default.name == "Core Failure"
 

--- a/tests/failure_criteria/cuntze_test.py
+++ b/tests/failure_criteria/cuntze_test.py
@@ -11,7 +11,6 @@ defaults = dict(
 
 
 def test_cuntze_criterion():
-
     cuntze_default = CuntzeCriterion()
     assert cuntze_default.name == "Cuntze"
 

--- a/tests/failure_criteria/face_sheet_wrinkling_test.py
+++ b/tests/failure_criteria/face_sheet_wrinkling_test.py
@@ -7,7 +7,6 @@ defaults = dict(zip(ATTRS_WRINKLING, [0.5, 0.33, 1.0]))
 
 
 def test_face_sheet_wrinkling_criterion():
-
     wrinkling_default = FaceSheetWrinklingCriterion()
     assert wrinkling_default.name == "Face Sheet Wrinkling"
 

--- a/tests/failure_criteria/hashin_test.py
+++ b/tests/failure_criteria/hashin_test.py
@@ -4,7 +4,6 @@ defaults = dict(zip(ATTRS_HASHIN, [True, True, False, 2, 1.0, 1.0, 1]))
 
 
 def test_hashin_criterion():
-
     hashin_default = HashinCriterion()
     assert hashin_default.name == "Hashin"
 

--- a/tests/failure_criteria/hoffman_test.py
+++ b/tests/failure_criteria/hoffman_test.py
@@ -5,7 +5,6 @@ ATTRS = ["wf", "dim"]
 
 
 def test_hoffman_criterion():
-
     hoffman_default = HoffmanCriterion()
     assert hoffman_default.name == "Hoffman"
 

--- a/tests/failure_criteria/larc_test.py
+++ b/tests/failure_criteria/larc_test.py
@@ -4,7 +4,6 @@ defaults = dict(zip(ATTRS_LARC, [True, True, True, True, 2, 1.0, 1.0, 1.0, 1.0])
 
 
 def test_larc_criterion():
-
     larc_default = LaRCCriterion()
     assert larc_default.name == "LaRC"
 

--- a/tests/failure_criteria/max_strain_criterion_test.py
+++ b/tests/failure_criteria/max_strain_criterion_test.py
@@ -32,7 +32,6 @@ defaults = dict(
 
 
 def test_max_strain_criterion():
-
     ms_default = MaxStrainCriterion()
     assert ms_default.name == "Max Strain"
 

--- a/tests/failure_criteria/max_stress_criterion_test.py
+++ b/tests/failure_criteria/max_stress_criterion_test.py
@@ -6,7 +6,6 @@ defaults = dict(
 
 
 def test_max_stress_criterion():
-
     ms_default = MaxStressCriterion()
     assert ms_default.name == "Max Stress"
 

--- a/tests/failure_criteria/puck_test.py
+++ b/tests/failure_criteria/puck_test.py
@@ -30,7 +30,6 @@ defaults = dict(
 
 
 def test_puck_criterion():
-
     puck_default = PuckCriterion()
     assert puck_default.name == "Puck"
 

--- a/tests/failure_criteria/shear_crimping_test.py
+++ b/tests/failure_criteria/shear_crimping_test.py
@@ -7,7 +7,6 @@ defaults = dict(zip(ATTRS_SHEAR_CRIMPING, [1.0, 0.0, 1.0]))
 
 
 def test_shear_crimping_criterion():
-
     sc_default = ShearCrimpingCriterion()
     assert sc_default.name == "Shear Crimping"
 

--- a/tests/failure_criteria/tsai_hill_test.py
+++ b/tests/failure_criteria/tsai_hill_test.py
@@ -5,7 +5,6 @@ ATTRS = ["wf", "dim"]
 
 
 def test_tsai_hill_criterion():
-
     th_default = TsaiHillCriterion()
     assert th_default.name == "Tsai Hill"
 

--- a/tests/failure_criteria/tsai_wu_test.py
+++ b/tests/failure_criteria/tsai_wu_test.py
@@ -5,7 +5,6 @@ ATTRS = ["wf", "dim"]
 
 
 def test_tsai_wu_criterion():
-
     tw_default = TsaiWuCriterion()
     assert tw_default.name == "Tsai Wu"
 

--- a/tests/failure_criteria/von_mises_test.py
+++ b/tests/failure_criteria/von_mises_test.py
@@ -4,7 +4,6 @@ defaults = dict(zip(ATTRS_VON_MISES, [True, True, 1.0, 1.0, False]))
 
 
 def test_von_mises_criterion():
-
     von_mises_default = VonMisesCriterion()
     assert von_mises_default.name == "Von Mises"
 

--- a/tests/filter_layered_data_test.py
+++ b/tests/filter_layered_data_test.py
@@ -178,7 +178,6 @@ def test_access_to_invalid_analysis_ply(dpf_server):
     )
     # try to get non existing analysis ply
     with pytest.raises(RuntimeError) as exc_info:
-
         analysis_ply_info_provider = AnalysisPlyInfoProvider(
             mesh=setup_result.mesh, name="notexisting"
         )

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -23,7 +23,6 @@ class Timer:
         self.timings.append((label, time.time()))
 
     def summary(self):
-
         diffs = self._get_diffs()
         print("")
         print("Timer summary")
@@ -61,7 +60,6 @@ class SetupResult:
 
 
 def setup_operators(server, files: ContinuousFiberCompositesFiles):
-
     timer = Timer()
 
     files = upload_continuous_fiber_composite_files_to_server(data_files=files, server=server)

--- a/tests/material_properties_test.py
+++ b/tests/material_properties_test.py
@@ -102,7 +102,6 @@ def test_material_properties(dpf_server):
 
 
 def test_material_properties_fails_with_error_mesh_has_no_layup_info(dpf_server):
-
     files = get_basic_shell_files()
     files = upload_continuous_fiber_composite_files_to_server(data_files=files, server=dpf_server)
 

--- a/tests/performance_test.py
+++ b/tests/performance_test.py
@@ -332,7 +332,6 @@ def test_performance_flat(dpf_server):
     timer.add("indexer")
 
     with setup_result.mesh.elements.connectivities_field.as_local_field() as local_connectivity:
-
         timer.add("local connectivity")
 
         for element_id in scope:


### PR DESCRIPTION
Stacked PR on top of #257 

* Update pre-commit dependencies.
* Add and run the `pyupgrade` pre-commit hook.
* Remove `TYPE_CHECKING` guards for `numpy.typing`.
* Set the minimum requirement for `numpy` to `1.22`.